### PR TITLE
Create README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+# Hubolab_summer
+
+The urdf of quadrupedal manipulator is in railab_summer/rsc/anymal_c_arm, and the learning codes are in railab_summer/raisimGymTorch/. There are 3 directories which have locomotion and manipulator control with whole body learning code, tracking end effector code, and ball throwing test code (not complete).


### PR DESCRIPTION
# Hubolab_summer

The urdf of quadrupedal manipulator is in railab_summer/rsc/anymal_c_arm, and the learning codes are in railab_summer/raisimGymTorch/. There are 3 directories which have locomotion and manipulator control with whole body learning code, tracking end effector code, and ball throwing test code (not complete).
